### PR TITLE
[WIP] Be able to configure tile timeout from uri options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tilelive-mapnik changelog
 
+## 0.6.18-cdb3 (not realesed)
+
+* Be able to configure tile timeout.
+
 ## 0.6.18-cdb2
 
 * Allow to configure buffer-size to 0


### PR DESCRIPTION
As part of platform limits milestone and in order to give more flexibility to the current tile timeout mechanism we need to be able to receive a timeout in `ms` from options and apply it.

cc @rochoa @saleiva @jorgesancha 