### PR TITLE
Avoid to fire timeout callback twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
- - "0.10"
  - "4"
  - "6"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tilelive-mapnik changelog
 
+## 0.6.18-cdb3 (not realesed)
+
+* Be able to configure tile timeout.
+
 ## 0.6.18-cdb2
 
 * Allow to configure buffer-size to 0

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -7,6 +7,7 @@ var mapnik = require('mapnik');
 var qs = require('querystring');
 var Pool = require('generic-pool').Pool;
 var LockingCache = require('./lockingcache');
+var timeoutDecorator = require('./utils/timeout-decorator');
 
 // node-mapnik >= 1.3 no long auto-registers plugins
 // so we do it here
@@ -53,6 +54,11 @@ function MapnikSource(uri, callback) {
     }
     // cache used to skip encoding of solid images
     this.solidCache = {};
+
+    if (uri.query && uri.query.limits && uri.query.limits.render > 0) {
+        this.getTile = timeoutDecorator(this.getTile.bind(this), uri.query.limits.render);
+    }
+
     return undefined;
 }
 
@@ -91,7 +97,6 @@ MapnikSource.prototype._normalizeURI = function(uri) {
     else uri.query.autoLoadFonts = as_bool(uri.query.autoLoadFonts);
     uri.query.limits = uri.query.limits || {};
     if (typeof uri.query.limits.render === 'undefined') uri.query.limits.render = 0;
-    if (typeof uri.query.limits.cacheOnTimeout === 'undefined') uri.query.limits.cacheOnTimeout = true;
     uri.query.metatileCache = uri.query.metatileCache || {};
     // Time to live in ms for cached tiles/grids
     // When set to 0 and `deleteOnHit` set to `false` object won't be removed

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -57,6 +57,7 @@ function MapnikSource(uri, callback) {
 
     if (uri.query && uri.query.limits && uri.query.limits.render > 0) {
         this.getTile = timeoutDecorator(this.getTile.bind(this), uri.query.limits.render);
+        this.getGrid = timeoutDecorator(this.getGrid.bind(this), uri.query.limits.render);
     }
 
     return undefined;

--- a/lib/render.js
+++ b/lib/render.js
@@ -198,33 +198,20 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
                     source._stats.render++;
                     var renderStats = {};
                     var renderStartTime = Date.now();
-
-                    var timedOut = false;
-                    var renderTimeoutId;
-                    if (options.limits.render > 0) {
-                        var renderLimit = options.limits.render * Math.max(1, meta.tiles.length);
-                        renderTimeoutId = setTimeout(function onRenderTimeout() {
-                            timedOut = true;
-                            callback(new Error('Render timed out'));
-                        }, renderLimit);
-                    }
-
                     map.render(image, options, function(err, image) {
-                        clearTimeout(renderTimeoutId);
                         process.nextTick(function() {
                             // Release after the .render() callback returned
                             // to avoid mapnik errors.
                             source._pool.release(map);
                         });
-                        if (!timedOut || options.limits.cacheOnTimeout) {
-                            if (err) return callback(err);
-                            if (meta.tiles.length > 1) {
-                                renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
-                                sliceMetatile(source, image, options, meta, renderStats, callback);
-                            } else {
-                                renderStats.render = Date.now() - renderStartTime;
-                                encodeSingleTile(source, image, options, meta, renderStats, callback);
-                            }
+
+                        if (err) return callback(err);
+                        if (meta.tiles.length > 1) {
+                            renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
+                            sliceMetatile(source, image, options, meta, renderStats, callback);
+                        } else {
+                            renderStats.render = Date.now() - renderStartTime;
+                            encodeSingleTile(source, image, options, meta, renderStats, callback);
                         }
                     });
                 } catch(err) {

--- a/lib/utils/timeout-decorator.js
+++ b/lib/utils/timeout-decorator.js
@@ -1,0 +1,23 @@
+module.exports = function timeoutDecorator(fn, ms) {
+  return function () {
+    var timeout = false;
+    var args = [].slice.call(arguments, 0, arguments.length - 1);
+    var callback = arguments[arguments.length - 1];
+
+    var timeoutId = setTimeout(function () {
+      timeout = true;
+      var err = new Error('Render timed out');
+      callback(err);
+    }, ms);
+
+    args.push(function decoratorCallback () {
+      if (timeout) {
+        return;
+      }
+      clearTimeout(timeoutId);
+      callback.apply(null, arguments);
+    })
+
+    fn.apply(null, args);
+  }
+}

--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -1,0 +1,45 @@
+var fs = require('fs');
+var assert = require('./support/assert');
+var MapnikBackend = require('..');
+var util = require('util');
+
+describe('Timeout', function () {
+    var completion = {};
+    var baseUri = {
+        pathname: './test/data/world.xml',
+        query: {
+            limits: {
+                render: 1,
+                cacheOnTimeout: true
+            }
+        },
+        protocol: 'mapnik:',
+        strict: false
+    };
+
+    var coords = [ 0, 0, 0 ];
+
+    it('should fire timeout', function (done) {
+        new MapnikBackend(baseUri, function (err, source) {
+            if (err) return done(err);
+            source.getTile(coords[0], coords[1], coords[2], function (err) {
+                assert.ok(err);
+                assert.equal('Render timed out', err.message);
+                done();
+            });
+        });
+    });
+
+    it('should not fire timeout', function (done) {
+        var uri = Object.assign({ query: { limits: { render: 0 } } }, baseUri);
+        new MapnikBackend(uri, function (err, source) {
+            if (err) return done(err);
+            this.source.getTile(coords[0], coords[1], coords[2], function (err, tile, headers) {
+                assert.ifError(err);
+                assert.ok(tile);
+                assert.ok(headers);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
It ensures that we don't fire callback twice after timeout had expired. It still does the work downstream after timeout but doesn't fire the callback upstream.

It drops usage of `cacheOnTimeout` parameter since cache is enabled it doesn't make sense to not cache if timeout fires. Also I'm dropping support for Node 0.10.x to be able to use `Object.assign`. Considering to do it in a separate PR. ;)

cc/ @rochoa