### PR TITLE
Return Mapnik's metrics with metatiles too

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -2,6 +2,7 @@
 
 ## 0.6.18-cdb11
 * Add support for render time variables
+* Return Mapnik metrics with metatiles
 
 ## 0.6.18-cdb10
 * Set @carto/mapnik to [`3.6.2-carto.7`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto7)

--- a/lib/render.js
+++ b/lib/render.js
@@ -47,7 +47,7 @@ function calculateMetatile(options) {
 }
 
 exports['sliceMetatile'] = sliceMetatile;
-function sliceMetatile(source, image, options, meta, stats, callback) {
+function sliceMetatile(source, source_image, options, meta, stats, callback) {
     var tiles = {};
 
     Step(function() {
@@ -57,18 +57,20 @@ function sliceMetatile(source, image, options, meta, stats, callback) {
             var key = [options.format, c[0], c[1], c[2]].join(',');
             var encodeStartTime = Date.now();
             getImage(source,
-                     image,
+                     source_image,
                      options,
                      (c[1] - meta.x) * options.tileSize,
                      (c[2] - meta.y) * options.tileSize,
                      function(err, image) {
+                var stats_tile = Object.keys(stats).reduce(function(previous, current) {
+                        previous[current] = stats[current];
+                        return previous;
+                }, { encode: Date.now() - encodeStartTime });
+                stats_tile = Object.assign(stats_tile, source_image.get_metrics());
                 tiles[key] = {
                     image: image,
                     headers: options.headers,
-                    stats: Object.keys(stats).reduce(function(previous, current) {
-                        previous[current] = stats[current];
-                        return previous;
-                    }, { encode: Date.now() - encodeStartTime })
+                    stats: stats_tile
                 };
                 next();
             });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -239,6 +239,27 @@ describe('Render ', function() {
             });
         });
     });
+
+    it('Works with metatiles', function(done) {
+        var uri = {
+            protocol : "mapnik:",
+            pathname : "./test/data/world.xml",
+            metatile: 4,
+            query : {
+                metrics : true
+            }
+        };
+
+        new mapnik_backend(uri, function(err, source) {
+            if (err) throw err;
+            source.getTile(2, 2, 2, function(err, info, headers, stats) {
+                assert(!err);
+                assert.ok(stats.hasOwnProperty('Mapnik'));
+                source.close(done);
+            });
+        });
+    });
+
 });
 
 


### PR DESCRIPTION
Fixes a bug where Mapnik metrics were not being returned if metatiling was on.

I've dediced to to divide Mapnik metrics (as it's done with `render`) so we can have all the data available. This means that some Metrics might show N-duplicated, which might overrepresent that request, but I'd rather have full data from Mapnik. 

Pending updating NEWs once the other PR is merged.