### PR TITLE
Remove step and calls to process.nextTick

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -3,7 +3,7 @@
 ## 0.6.18-cdb15
 * Update @carto/mapnik to [`3.6.2-carto.11`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto.11/CHANGELOG.carto.md#362-carto11).
 * Dev: Set mocha dependency to `5.2.0`.
-* Update `generic-pool` to `3.4.2`.
+* Update `generic-pool` to `2.5.4`.
 * Remove `step` and calls to `nextTick`.
 * Remove unused `sphericalmercator`.
 

--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -3,6 +3,9 @@
 ## 0.6.18-cdb15
 * Update @carto/mapnik to [`3.6.2-carto.11`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto.11/CHANGELOG.carto.md#362-carto11).
 * Dev: Set mocha dependency to `5.2.0`.
+* Update `generic-pool` to `3.4.2`.
+* Remove `step` and calls to `nextTick`.
+* Remove unused `sphericalmercator`.
 
 ## 0.6.18-cdb14
 * Set @carto/mapnik to [`3.6.2-carto.10`](https://github.com/CartoDB/node-mapnik/blob/v3.6.2-carto/CHANGELOG.carto.md#362-carto10)

--- a/lib/lockingcache.js
+++ b/lib/lockingcache.js
@@ -65,21 +65,19 @@ LockingCache.prototype.clear = function() {
 
 LockingCache.prototype.trigger = function(id) {
     if (this.results[id] && this.results[id] !== true) {
-        process.nextTick(function() {
-            var data = this.results[id];
-            var callbacks = this.callbacks[id] || [];
+        var data = this.results[id];
+        var callbacks = this.callbacks[id] || [];
 
-            if (this.timeout === 0 || this.deleteOnHit) {
-                // instant purge with the first put() for a key
-                // clears timeouts and results
-                this.del(id);
-            } else {
-                delete this.callbacks[id];
-            }
+        if (this.timeout === 0 || this.deleteOnHit) {
+            // instant purge with the first put() for a key
+            // clears timeouts and results
+            this.del(id);
+        } else {
+            delete this.callbacks[id];
+        }
 
-            callbacks.forEach(function(callback) {
-                callback.apply(callback, data);
-            });
-        }.bind(this));
+        callbacks.forEach(function(callback) {
+            callback.apply(callback, data);
+        });
     }
 };

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -15,7 +15,6 @@ var cache = {};
 
 exports = module.exports = MapnikSource;
 
-require('util').inherits(MapnikSource, require('events').EventEmitter);
 function MapnikSource(uri, callback) {
     uri = this._normalizeURI(uri);
 
@@ -23,42 +22,42 @@ function MapnikSource(uri, callback) {
         return callback(new Error('Only the mapnik protocol is supported'));
     }
 
-    var key = JSON.stringify(uri);
+    if (uri.query && uri.query.limits && uri.query.limits.render > 0) {
+        this.getTile = timeoutDecorator(this.getTile.bind(this), uri.query.limits.render);
+        this.getGrid = timeoutDecorator(this.getGrid.bind(this), uri.query.limits.render);
+    }
+
+    // cache used to skip encoding of solid images
+    this.solidCache = {};
 
     // by default we use an internal self-caching mechanism but
     // calling applications can pass `internal_cache:false` to disable
     // TODO - consider removing completely once https://github.com/mapbox/tilemill/issues/1893
     // is in place and a solid reference implementation of external caching
     if (uri.query.internal_cache === false) {
-        this.once('open', callback);
-        this._open(uri);
+        this._open(uri, callback);
     } else {
+        const key = JSON.stringify(uri);
+
         // https://github.com/mapbox/tilelive-mapnik/issues/47
         if (!cache[key]) {
             cache[key] = this;
             this._self_cache_key = key;
-            this._open(uri);
+            return this._open(uri, callback);
         }
-        var source = cache[key];
-        source.setMaxListeners(0);
-        if (!source.open) {
-            source.once('open', function(err, source) {
+
+        const source = cache[key];
+        if (source.open) {
+            return callback(null, source);
+        }
+        else
+        {
+            return this._open(uri, (err, source) => {
                 if (err) cache[key] = false;
                 callback(err, source);
             });
-        } else {
-            callback(null, source);
         }
     }
-    // cache used to skip encoding of solid images
-    this.solidCache = {};
-
-    if (uri.query && uri.query.limits && uri.query.limits.render > 0) {
-        this.getTile = timeoutDecorator(this.getTile.bind(this), uri.query.limits.render);
-        this.getGrid = timeoutDecorator(this.getGrid.bind(this), uri.query.limits.render);
-    }
-
-    return undefined;
 }
 
 MapnikSource.mapnik = mapnik;
@@ -136,7 +135,7 @@ MapnikSource.findID = function(filepath, id, callback) {
     });
 };
 
-MapnikSource.prototype._open = function(uri) {
+MapnikSource.prototype._open = function(uri, callback) {
     this._stats = {
         render: 0,          // # of times a render is requested from mapnik
         total: 0,           // # of tiles returned from source
@@ -167,11 +166,14 @@ MapnikSource.prototype._open = function(uri) {
     // Initialize this map. This wraps `localize()` and calls `create()`
     // afterwards to actually create a new Mapnik map object.
     this._loadXML((err, xml) => {
-        if (err) return this.emit('open', err);
+        if (err) return callback(err);
 
         this._createMetatileCache(uri.query.metatileCache);
         this._createPool(xml);
-        this._populateInfo();
+        this._populateInfo((err) => {
+            if (!err) this.open = true;
+            return callback(err, this);
+        });
     });
 };
 
@@ -237,10 +239,10 @@ MapnikSource.prototype._createPool = function(xml) {
     this._pool = Pool(factory);
 };
 
-MapnikSource.prototype._populateInfo = function() {
+MapnikSource.prototype._populateInfo = function(callback) {
     var id = path.basename(this._uri.pathname, path.extname(this._uri.pathname));
     this._pool.acquire((err, map) => {
-        if (err) return this.emit('open', err);
+        if (err) return callback(err);
 
         const info = { id: id, name: id, minzoom: 0, maxzoom: 22, autoscale: true };
         const p = map.parameters;
@@ -260,8 +262,7 @@ MapnikSource.prototype._populateInfo = function() {
             2 ];
         this._info = info;
         this._pool.release(map);
-        this.open = true;
-        this.emit('open', null, this);
+        return callback(null);
     });
 };
 

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -1,13 +1,11 @@
-var fs = require('fs');
-var crypto = require('crypto');
-var Step = require('step');
-var path = require('path');
-var url = require('url');
-var mapnik = require('@carto/mapnik');
-var qs = require('querystring');
-var Pool = require('generic-pool').Pool;
-var LockingCache = require('./lockingcache');
-var timeoutDecorator = require('./utils/timeout-decorator');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+const mapnik = require('@carto/mapnik');
+const qs = require('querystring');
+const genericPool = require("generic-pool");
+const LockingCache = require('./lockingcache');
+const timeoutDecorator = require('./utils/timeout-decorator');
 
 // node-mapnik >= 1.3 no long auto-registers plugins
 // so we do it here
@@ -22,7 +20,7 @@ function MapnikSource(uri, callback) {
     uri = this._normalizeURI(uri);
 
     if (uri.protocol && uri.protocol !== 'mapnik:') {
-        throw new Error('Only the mapnik protocol is supported');
+        callback(new Error('Only the mapnik protocol is supported'));
     }
 
     var key = JSON.stringify(uri);
@@ -139,13 +137,6 @@ MapnikSource.findID = function(filepath, id, callback) {
 };
 
 MapnikSource.prototype._open = function(uri) {
-    var source = this;
-    function error(err) {
-        process.nextTick(function() {
-            source.emit('open', err);
-        });
-    }
-
     this._stats = {
         render: 0,          // # of times a render is requested from mapnik
         total: 0,           // # of tiles returned from source
@@ -207,13 +198,11 @@ MapnikSource.prototype._close = function(callback) {
     if (this._tileCache) this._tileCache.clear();
     // https://github.com/coopernurse/node-pool/issues/17#issuecomment-6565795
     if (this._pool) {
-        var pool = this._pool;
-        // NOTE: .drain() and .destoryAllNow() do
-        // not pass error args
-        pool.drain(function() {
-            pool.destroyAllNow(function() {
-                return callback();
-            });
+        const pool = this._pool;
+        const p = pool.drain()
+        .then(function() {
+            pool.clear();
+            return callback();
         });
     }
 };
@@ -226,52 +215,64 @@ MapnikSource.registerProtocols = function(tilelive) {
 // can be expected to be in `mapfile`. If this isn't successful, `callback` gets
 // an error as its first argument.
 MapnikSource.prototype._loadXML = function(callback) {
-    var source = this;
-    this._base = path.resolve(path.dirname(this._uri.pathname));
+    if (this._uri.pathname) {
+        this._base = path.resolve(path.dirname(this._uri.pathname));
+    }
 
     // This is a string-based map file. Pass it on literally.
     if (this._uri.xml) return callback(null, this._uri.xml);
 
     // Load XML from file.
-    fs.readFile(path.resolve(source._uri.pathname), 'utf8', function(err, xml) {
-        if (err) return callback(err);
-        callback(null, xml);
+    fs.readFile(path.resolve(this._uri.pathname), 'utf8', (err, xml) => {
+        callback(err, xml);
     });
 };
 
 // Create a new mapnik map object at `this.mapnik`. Requires that the mapfile
 // be localized with `this.localize()`. This can be called in repetition because
 // it won't recreate `this.mapnik`.
-MapnikSource.prototype._createPool = function(xml, callback) {
-    var source = this;
-    if (!this._pool) this._pool = Pool({
-        create: function(callback) {
-            var map = new mapnik.Map(source._uri.query.tileSize, source._uri.query.tileSize);
-            map.bufferSize = source._uri.query.bufferSize;
-            var opts = {strict: source._uri.strict || false, base: source._base + '/'};
-            try {
-                map.fromString(xml, opts, function(err, map) {
-                    if (err) return callback(err);
-                    return callback(null, map);
-                });
-            } catch (err) {
-                return callback(err);
-            }
+MapnikSource.prototype._createPool = function(xml) {
+    if (this._pool) return;
+
+    const opts = {
+        max: this._uri.query.poolSize || process.env.UV_THREADPOOL_SIZE || require('os').cpus().length
+    };
+    const factory = {
+        create: () => {
+            return new Promise((resolve, reject) => {
+                // Note that acquire() never resolves/rejects if factory always rejects
+                try {
+                    const map = new mapnik.Map(this._uri.query.tileSize, this._uri.query.tileSize);
+                    map.bufferSize = this._uri.query.bufferSize;
+                    const map_opts = {strict: this._uri.strict || false, base: this._base + '/'};
+                    map.fromString(xml, map_opts, (err_string, map) => {
+                        if (err_string) {
+                            delete map;
+                            resolve(err_string);
+                        }
+                        else resolve(map);
+                    });
+                } catch (exception) {
+                    resolve(exception);
+                }
+            });
         },
-        destroy: function(map) {
+        destroy : (map) => {
             delete map;
-        },
-        max: source._uri.query.poolSize || process.env.UV_THREADPOOL_SIZE || require('os').cpus().length
-    });
-    callback(null);
+        }
+    };
+
+    this._pool = genericPool.createPool(factory, opts);
 };
 
-MapnikSource.prototype._populateInfo = function(callback) {
-    var source = this;
+MapnikSource.prototype._populateInfo = function() {
     var id = path.basename(this._uri.pathname, path.extname(this._uri.pathname));
-
-    this._pool.acquire(function(err, map) {
-        if (err) return callback(err);
+    const mapPromise = this._pool.acquire()
+    .then(map => {
+        if (map instanceof Error) {
+            this._pool.release(map);
+            return this.emit('open', map);
+        }
 
         var info = { id: id, name: id, minzoom: 0, maxzoom: 22, autoscale: true };
 
@@ -290,11 +291,12 @@ MapnikSource.prototype._populateInfo = function(callback) {
             (info.bounds[2] - info.bounds[0]) / 2 + info.bounds[0],
             (info.bounds[3] - info.bounds[1]) / 2 + info.bounds[1],
             2 ];
-
-        source._info = info;
-        source._pool.release(map);
-        callback(null)
-    });
+        this._info = info;
+        this._pool.release(map);
+        this.open = true;
+        this.emit('open', null, this);
+    })
+    .catch(err => this.emit('open', err));
 };
 
 // Creates a locking cache that generates tiles. When requesting the same tile

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -3,7 +3,7 @@ const path = require('path');
 const url = require('url');
 const mapnik = require('@carto/mapnik');
 const qs = require('querystring');
-const genericPool = require("generic-pool");
+const Pool = require("generic-pool").Pool;
 const LockingCache = require('./lockingcache');
 const timeoutDecorator = require('./utils/timeout-decorator');
 
@@ -191,10 +191,8 @@ MapnikSource.prototype._close = function(callback) {
     // https://github.com/coopernurse/node-pool/issues/17#issuecomment-6565795
     if (this._pool) {
         const pool = this._pool;
-        const p = pool.drain()
-        .then(function() {
-            pool.clear();
-            return callback();
+        pool.drain(() => {
+            pool.destroyAllNow(callback);
         });
     }
 };
@@ -224,50 +222,34 @@ MapnikSource.prototype._loadXML = function(callback) {
 MapnikSource.prototype._createPool = function(xml) {
     if (this._pool) return;
 
-    const opts = {
-        max: this._uri.query.poolSize || process.env.UV_THREADPOOL_SIZE || require('os').cpus().length
-    };
     const factory = {
-        create: () => {
-            return new Promise((resolve, reject) => {
-                // Note that acquire() never resolves/rejects if factory always rejects
-                try {
-                    const map = new mapnik.Map(this._uri.query.tileSize, this._uri.query.tileSize);
-                    map.bufferSize = this._uri.query.bufferSize;
-                    const map_opts = {strict: this._uri.strict || false, base: this._base + '/'};
-                    map.fromString(xml, map_opts, (err_string, map) => {
-                        if (err_string) {
-                            delete map;
-                            resolve(err_string);
-                        }
-                        else resolve(map);
-                    });
-                } catch (exception) {
-                    resolve(exception);
-                }
-            });
+        create: (callback) => {
+            try {
+                const map = new mapnik.Map(this._uri.query.tileSize, this._uri.query.tileSize);
+                map.bufferSize = this._uri.query.bufferSize;
+                const map_opts = {strict: this._uri.strict || false, base: this._base + '/'};
+                return map.fromString(xml, map_opts, callback);
+            } catch (err) {
+                return callback(err);
+            }
         },
         destroy : (map) => {
             delete map;
-        }
+        },
+        max: this._uri.query.poolSize || process.env.UV_THREADPOOL_SIZE || require('os').cpus().length
     };
 
-    this._pool = genericPool.createPool(factory, opts);
+    this._pool = Pool(factory);
 };
 
 MapnikSource.prototype._populateInfo = function() {
     var id = path.basename(this._uri.pathname, path.extname(this._uri.pathname));
-    const mapPromise = this._pool.acquire()
-    .then(map => {
-        if (map instanceof Error) {
-            this._pool.release(map);
-            return this.emit('open', map);
-        }
+    this._pool.acquire((err, map) => {
+        if (err) return this.emit('open', err);
 
-        var info = { id: id, name: id, minzoom: 0, maxzoom: 22, autoscale: true };
-
-        var p = map.parameters;
-        for (var key in p) info[key] = p[key];
+        const info = { id: id, name: id, minzoom: 0, maxzoom: 22, autoscale: true };
+        const p = map.parameters;
+        for (const key in p) info[key] = p[key];
         if (p.bounds) info.bounds = p.bounds.split(',').map(parseFloat);
         if (p.center) info.center = p.center.split(',').map(parseFloat);
         if (p.minzoom) info.minzoom = parseInt(p.minzoom, 10);
@@ -285,18 +267,17 @@ MapnikSource.prototype._populateInfo = function() {
         this._pool.release(map);
         this.open = true;
         this.emit('open', null, this);
-    })
-    .catch(err => this.emit('open', err));
+    });
 };
 
 // Creates a locking cache that generates tiles. When requesting the same tile
 // multiple times, they'll be grouped to one request.
 MapnikSource.prototype._createMetatileCache = function(options) {
-    var source = this;
+    const source = this;
     this._tileCache = new LockingCache(function(key) {
-        var cache = this;
-        var coords = key.split(',');
-        var keys = source._renderMetatile({
+        const cache = this;
+        const coords = key.split(',');
+        return source._renderMetatile({
             metatile: source._uri.query.metatile,
             tileSize: source._uri.query.tileSize,
             buffer_size: source.bufferSize,
@@ -307,24 +288,15 @@ MapnikSource.prototype._createMetatileCache = function(options) {
             y: +coords[3],
             metrics: source._uri.query.metrics,
             variables: source._uri.query.variables
-        }, function(err, tiles) {
+        }, function(err, keys, tiles) {
             if (err) {
-                // Push error objects to all entries that were supposed to
-                // be generated.
-                keys.forEach(function(key) {
-                    cache.put(key, err);
-                });
+                // Push error objects to all entries that were supposed to be generated.
+                keys.forEach((key) => cache.put(key, err));
             } else {
                 // Put all the generated tiles into the locking cache.
-                for (var key in tiles) {
-                    cache.put(key, null, tiles[key].image, tiles[key].headers, tiles[key].stats);
-                }
+                keys.forEach((key) => cache.put(key, null, tiles[key].image, tiles[key].headers, tiles[key].stats));
             }
         });
-
-        // Return a list of all the tile coordinates that are being rendered
-        // as part of this metatile.
-        return keys;
     },
     { timeout: options.ttl, deleteOnHit: options.deleteOnHit }); // purge immediately after callbacks
 };

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -266,14 +266,59 @@ MapnikSource.prototype._populateInfo = function(callback) {
     });
 };
 
+exports['calculateMetatile'] = calculateMetatile;
+function calculateMetatile(options) {
+    const EARTH_RADIUS = 6378137;
+    const EARTH_DIAMETER = EARTH_RADIUS * 2;
+    const EARTH_CIRCUMFERENCE = EARTH_DIAMETER * Math.PI;
+    const MAX_RES = EARTH_CIRCUMFERENCE / 256;
+    const ORIGIN_SHIFT = EARTH_CIRCUMFERENCE/2;
+
+    const z = +options.z;
+    let x = +options.x;
+    let y = +options.y;
+    const total = Math.pow(2, z);
+    const resolution = MAX_RES / total;
+
+    // Make sure we start at a metatile boundary.
+    x -= x % options.metatile;
+    y -= y % options.metatile;
+
+    // Make sure we don't calculcate a metatile that is larger than the bounds.
+    const metaWidth  = Math.min(options.metatile, total, total - x);
+    const metaHeight = Math.min(options.metatile, total, total - y);
+
+    // Generate all tile coordinates that are within the metatile.
+    const tiles = [];
+    for (let dx = 0; dx < metaWidth; dx++) {
+        for (let dy = 0; dy < metaHeight; dy++) {
+            tiles.push([ z, x + dx, y + dy ]);
+        }
+    }
+
+    const minx = (x * 256) * resolution - ORIGIN_SHIFT;
+    const miny = -((y + metaHeight) * 256) * resolution + ORIGIN_SHIFT;
+    const maxx = ((x + metaWidth) * 256) * resolution - ORIGIN_SHIFT;
+    const maxy = -((y * 256) * resolution - ORIGIN_SHIFT);
+    return {
+        width: metaWidth * options.tileSize,
+        height: metaHeight * options.tileSize,
+        x: x,
+        y: y,
+        tiles: tiles,
+        bbox: [ minx, miny, maxx, maxy ]
+    };
+}
+
 // Creates a locking cache that generates tiles. When requesting the same tile
 // multiple times, they'll be grouped to one request.
 MapnikSource.prototype._createMetatileCache = function(options) {
     const source = this;
-    this._tileCache = new LockingCache(function(key) {
+    this._tileCache = new LockingCache(function(cache_input) {
         const cache = this;
-        const coords = key.split(',');
-        return source._renderMetatile({
+
+        const coords = cache_input.split(',');
+        const options = {
             metatile: source._uri.query.metatile,
             tileSize: source._uri.query.tileSize,
             buffer_size: source.bufferSize,
@@ -283,16 +328,32 @@ MapnikSource.prototype._createMetatileCache = function(options) {
             x: +coords[2],
             y: +coords[3],
             metrics: source._uri.query.metrics,
-            variables: source._uri.query.variables
-        }, function(err, keys, tiles) {
+            variables: source._uri.query.variables || {}
+        };
+
+        // Calculate bbox from xyz, respecting metatile settings.
+        const metatile = calculateMetatile(options);
+
+        // Set x, y, z based on the metatile boundary
+        options.x = metatile.x;
+        options.y = metatile.y;
+        options.variables.zoom = options.z;
+
+        const cache_keys = metatile.tiles.map(function(tile) {
+            return options.format + ',' + tile.join(',');
+        });
+        
+        source._renderMetatile(options, metatile, function(err, tiles) {
             if (err) {
                 // Push error objects to all entries that were supposed to be generated.
-                keys.forEach((key) => cache.put(key, err));
+                cache_keys.forEach((key) => cache.put(key, err));
             } else {
                 // Put all the generated tiles into the locking cache.
-                keys.forEach((key) => cache.put(key, null, tiles[key].image, tiles[key].headers, tiles[key].stats));
+                cache_keys.forEach((key) => cache.put(key, null, tiles[key].image, tiles[key].headers, tiles[key].stats));
             }
         });
+
+        return cache_keys;
     },
     { timeout: options.ttl, deleteOnHit: options.deleteOnHit }); // purge immediately after callbacks
 };

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -20,7 +20,7 @@ function MapnikSource(uri, callback) {
     uri = this._normalizeURI(uri);
 
     if (uri.protocol && uri.protocol !== 'mapnik:') {
-        callback(new Error('Only the mapnik protocol is supported'));
+        return callback(new Error('Only the mapnik protocol is supported'));
     }
 
     var key = JSON.stringify(uri);
@@ -215,9 +215,7 @@ MapnikSource.prototype._loadXML = function(callback) {
     if (this._uri.xml) return callback(null, this._uri.xml);
 
     // Load XML from file.
-    fs.readFile(path.resolve(this._uri.pathname), 'utf8', (err, xml) => {
-        callback(err, xml);
-    });
+    fs.readFile(path.resolve(this._uri.pathname), 'utf8', callback);
 };
 
 // Create a new mapnik map object at `this.mapnik`. Requires that the mapfile

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -9,7 +9,7 @@ const timeoutDecorator = require('./utils/timeout-decorator');
 
 // node-mapnik >= 1.3 no long auto-registers plugins
 // so we do it here
-if (mapnik.register_default_input_plugins) mapnik.register_default_input_plugins()
+if (mapnik.register_default_input_plugins) mapnik.register_default_input_plugins();
 
 var cache = {};
 
@@ -74,7 +74,7 @@ function as_bool(val) {
 
 MapnikSource.prototype._normalizeURI = function(uri) {
     if (typeof uri === 'string') uri = url.parse(uri, true);
-    if (uri.hostname === '.' || uri.hostname == '..') {
+    if (uri.hostname === '.' || uri.hostname === '..') {
         uri.pathname = uri.hostname + uri.pathname;
         delete uri.hostname;
         delete uri.host;
@@ -180,9 +180,7 @@ MapnikSource.prototype._open = function(uri) {
 };
 
 MapnikSource.prototype.close = function(callback) {
-    this._close(function() {
-        return callback();
-    });
+    this._close(callback);
 };
 
 MapnikSource.prototype._cache = cache;

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -166,22 +166,16 @@ MapnikSource.prototype._open = function(uri) {
 
     // Initialize this map. This wraps `localize()` and calls `create()`
     // afterwards to actually create a new Mapnik map object.
-    Step(function() {
-        source._loadXML(this);
-    }, function(err, xml) {
-        if (err) return error(err);
-        // https://github.com/mapbox/tilelive-mapnik/issues/25
-        // there seems to be no value to assinging xml to a property
-        //source._xml = xml;
-        source._createMetatileCache(uri.query.metatileCache);
-        source._createPool(xml, this);
-    }, function(err) {
-        if (err) return error(err);
-        source._populateInfo(this);
-    }, function(err) {
-        if (err) return error(err);
-        source.open = true;
-        source.emit('open', null, source);
+    this._loadXML((err, xml) => {
+        if (err) return this.emit('open', err);
+
+        this._createMetatileCache(uri.query.metatileCache);
+        this._createPool(xml);
+        this._populateInfo((err_populate) => {
+            if (err_populate) return this.emit('open', err_populate);
+            this.open = true;
+            this.emit('open', null, this);
+        });
     });
 };
 

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -201,9 +201,8 @@ MapnikSource.registerProtocols = function(tilelive) {
 // can be expected to be in `mapfile`. If this isn't successful, `callback` gets
 // an error as its first argument.
 MapnikSource.prototype._loadXML = function(callback) {
-    if (this._uri.pathname) {
-        this._base = path.resolve(path.dirname(this._uri.pathname));
-    }
+    this._base = path.resolve(path.dirname(this._uri.pathname));
+
 
     // This is a string-based map file. Pass it on literally.
     if (this._uri.xml) return callback(null, this._uri.xml);

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -171,11 +171,7 @@ MapnikSource.prototype._open = function(uri) {
 
         this._createMetatileCache(uri.query.metatileCache);
         this._createPool(xml);
-        this._populateInfo((err_populate) => {
-            if (err_populate) return this.emit('open', err_populate);
-            this.open = true;
-            this.emit('open', null, this);
-        });
+        this._populateInfo();
     });
 };
 

--- a/lib/mapnik_backend.js
+++ b/lib/mapnik_backend.js
@@ -47,16 +47,14 @@ function MapnikSource(uri, callback) {
         }
 
         const source = cache[key];
-        if (source.open) {
-            return callback(null, source);
-        }
-        else
-        {
-            return this._open(uri, (err, source) => {
-                if (err) cache[key] = false;
-                callback(err, source);
-            });
-        }
+        if (source.open) return callback(null, source);
+
+        return this._open(uri, (err, source) => {
+            if (err) {
+                cache[key] = false;
+            }
+            callback(err, source);
+        });
     }
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -155,6 +155,7 @@ function getImage(source, image, options, x, y, callback) {
 }
 
 // Render png/jpg/tif image or a utf grid and return an encoded buffer
+// Uses callback(err, keys, tiles). Returns keys
 MapnikSource.prototype._renderMetatile = function(options, callback) {
     var source = this;
 
@@ -190,46 +191,52 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
     // Add reference to the source allowing debug/stat reporting to be compiled.
     options.source = source;
 
-    const mapPromise = this._pool.acquire()
-    .then((map) => {
-        if (map instanceof Error) {
-            this._pool.release(map);
-            return callback(map);
-        }
+    const keys = meta.tiles.map(function(tile) {
+        return options.format + ',' + tile.join(',');
+    });
 
-        // Begin at metatile boundary.
-        options.x = meta.x;
-        options.y = meta.y;
-        options.variables.zoom = options.z;
-        map.resize(meta.width, meta.height);
-        map.extent = meta.bbox;
-        try {
-            source._stats.render++;
-            var renderStats = {};
-            var renderStartTime = Date.now();
-            map.render(image, options, (err, image) => {
+    // acquire can throw if pool is draining
+    try {
+        this._pool.acquire((err, map) => {
+            if (err) return callback(err);
+
+            // Begin at metatile boundary.
+            options.x = meta.x;
+            options.y = meta.y;
+            options.variables.zoom = options.z;
+            map.resize(meta.width, meta.height);
+            map.extent = meta.bbox;
+            try {
+                source._stats.render++;
+                const renderStats = {};
+                const renderStartTime = Date.now();
+                map.render(image, options, (err, image) => {
+                    this._pool.release(map);
+                    if (err) {
+                        return callback(err);
+                    }
+                    if (meta.tiles.length > 1) {
+                        renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
+                        sliceMetatile(source, image, options, meta, renderStats, (err, tiles) => {
+                            return callback(err, keys, tiles);
+                        });
+                    } else {
+                        renderStats.render = Date.now() - renderStartTime;
+                        encodeSingleTile(source, image, options, meta, renderStats, (err, tiles) => {
+                            return callback(err, keys, tiles);
+                        });
+                    }
+                });
+            } catch(err) {
                 this._pool.release(map);
-                if (err) {
-                    return callback(err);
-                }
-                if (meta.tiles.length > 1) {
-                    renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
-                    sliceMetatile(source, image, options, meta, renderStats, callback);
-                } else {
-                    renderStats.render = Date.now() - renderStartTime;
-                    encodeSingleTile(source, image, options, meta, renderStats, callback);
-                }
-            });
-        } catch(err) {
-            this._pool.release(map);
-            return callback(err);
-        }
-    })
-    .catch(err => callback(err));
+                return callback(err, keys);
+            }
+        });
+    } catch (err) {
+        return callback(err, keys);
+    }
 
     // Return a list of all the tile coordinates that are being rendered
     // as part of this metatile.
-    return meta.tiles.map(function(tile) {
-        return options.format + ',' + tile.join(',');
-    });
+    return keys;
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -186,52 +186,42 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
     // Add reference to the source allowing debug/stat reporting to be compiled.
     options.source = source;
 
-    process.nextTick(function() {
-        // acquire can throw if pool is draining
+    const mapPromise = this._pool.acquire()
+    .then((map) => {
+        if (map instanceof Error) {
+            this._pool.release(map);
+            return callback(map);
+        }
+
+        // Begin at metatile boundary.
+        options.x = meta.x;
+        options.y = meta.y;
+        options.variables.zoom = options.z;
+        map.resize(meta.width, meta.height);
+        map.extent = meta.bbox;
         try {
-            source._pool.acquire(function(err, map) {
+            source._stats.render++;
+            var renderStats = {};
+            var renderStartTime = Date.now();
+            map.render(image, options, (err, image) => {
+                this._pool.release(map);
                 if (err) {
                     return callback(err);
                 }
-                // Begin at metatile boundary.
-                options.x = meta.x;
-                options.y = meta.y;
-                options.variables.zoom = options.z;
-                map.resize(meta.width, meta.height);
-                map.extent = meta.bbox;
-                try {
-                    source._stats.render++;
-                    var renderStats = {};
-                    var renderStartTime = Date.now();
-                    map.render(image, options, function(err, image) {
-                        process.nextTick(function() {
-                            // Release after the .render() callback returned
-                            // to avoid mapnik errors.
-                            source._pool.release(map);
-                        });
-
-                        if (err) return callback(err);
-                        if (meta.tiles.length > 1) {
-                            renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
-                            sliceMetatile(source, image, options, meta, renderStats, callback);
-                        } else {
-                            renderStats.render = Date.now() - renderStartTime;
-                            encodeSingleTile(source, image, options, meta, renderStats, callback);
-                        }
-                    });
-                } catch(err) {
-                    process.nextTick(function() {
-                        // Release after the .render() callback returned
-                        // to avoid mapnik errors.
-                        source._pool.release(map);
-                    });
-                    return callback(err);
+                if (meta.tiles.length > 1) {
+                    renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
+                    sliceMetatile(source, image, options, meta, renderStats, callback);
+                } else {
+                    renderStats.render = Date.now() - renderStartTime;
+                    encodeSingleTile(source, image, options, meta, renderStats, callback);
                 }
             });
-        } catch (err) {
+        } catch(err) {
+            this._pool.release(map);
             return callback(err);
         }
-    });
+    })
+    .catch(err => callback(err));
 
     // Return a list of all the tile coordinates that are being rendered
     // as part of this metatile.

--- a/lib/render.js
+++ b/lib/render.js
@@ -143,7 +143,7 @@ function getImage(source, image, options, x, y, callback) {
                 return callback(null, buffer);
             }
 
-            if (options.format == 'utf') {
+            if (options.format === 'utf') {
                 view.encode(options, encodeCallback);
             } else {
                 view.encode(options.format, options, encodeCallback);
@@ -171,10 +171,10 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
     } else {
         // NOTE: formats use mapnik syntax like `png8:m=h` or `jpeg80`
         // so we need custom handling for png/jpeg
-        if (options.format.indexOf('png') != -1) {
+        if (options.format.indexOf('png') !== -1) {
             options.headers = { 'Content-Type': 'image/png' };
-        } else if (options.format.indexOf('jpeg') != -1 ||
-                   options.format.indexOf('jpg') != -1) {
+        } else if (options.format.indexOf('jpeg') !== -1 ||
+                   options.format.indexOf('jpg') !== -1) {
             options.headers = { 'Content-Type': 'image/jpeg' };
         } else {
             // will default to 'application/octet-stream' if unable to detect

--- a/lib/render.js
+++ b/lib/render.js
@@ -174,7 +174,7 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
             options.headers = { 'Content-Type': 'image/jpeg' };
         } else {
             // will default to 'application/octet-stream' if unable to detect
-            options.headers = { 'Content-Type': mime.lookup(options.format.split(':')[0]) };
+            options.headers = { 'Content-Type': mime.getType(options.format.split(':')[0]) };
         }
         var image = new mapnik.Image(meta.width, meta.height);
     }

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,14 +1,13 @@
-var mapnik = require('@carto/mapnik');
-var Step = require('step');
-var mime = require('mime')
+const mapnik = require('@carto/mapnik');
+const mime = require('mime');
 
-var MapnikSource = require('./mapnik_backend');
+const MapnikSource = require('./mapnik_backend');
 
-var EARTH_RADIUS = 6378137;
-var EARTH_DIAMETER = EARTH_RADIUS * 2;
-var EARTH_CIRCUMFERENCE = EARTH_DIAMETER * Math.PI;
-var MAX_RES = EARTH_CIRCUMFERENCE / 256;
-var ORIGIN_SHIFT = EARTH_CIRCUMFERENCE/2;
+const EARTH_RADIUS = 6378137;
+const EARTH_DIAMETER = EARTH_RADIUS * 2;
+const EARTH_CIRCUMFERENCE = EARTH_DIAMETER * Math.PI;
+const MAX_RES = EARTH_CIRCUMFERENCE / 256;
+const ORIGIN_SHIFT = EARTH_CIRCUMFERENCE/2;
 
 
 exports['calculateMetatile'] = calculateMetatile;
@@ -48,36 +47,41 @@ function calculateMetatile(options) {
 
 exports['sliceMetatile'] = sliceMetatile;
 function sliceMetatile(source, source_image, options, meta, stats, callback) {
-    var tiles = {};
+    const tiles_length = meta.tiles.length;
+    if (tiles_length === 0) {
+        callback(null, {});
+    }
 
-    Step(function() {
-        var group = this.group();
-        meta.tiles.forEach(function(c) {
-            var next = group();
-            var key = [options.format, c[0], c[1], c[2]].join(',');
-            var encodeStartTime = Date.now();
-            getImage(source,
-                     source_image,
-                     options,
-                     (c[1] - meta.x) * options.tileSize,
-                     (c[2] - meta.y) * options.tileSize,
-                     function(err, image) {
-                var stats_tile = Object.keys(stats).reduce(function(previous, current) {
-                        previous[current] = stats[current];
-                        return previous;
-                }, { encode: Date.now() - encodeStartTime });
-                stats_tile = Object.assign(stats_tile, source_image.get_metrics());
-                tiles[key] = {
+    const tiles = {};
+    const err_num = 0;
+    let tile_num = 0;
+
+    meta.tiles.forEach(c => {
+        const key = [options.format, c[0], c[1], c[2]].join(',');
+        const encodeStartTime = Date.now();
+        const x = (c[1] - meta.x) * options.tileSize;
+        const y = (c[2] - meta.y) * options.tileSize;
+        getImage(source, source_image, options, x, y, (err, image) => {
+            tile_num++;
+            if (err) {
+                if (!err_num) return callback(err);
+                err_num++;
+            } else {
+                const stats_tile = Object.assign(
+                        stats,
+                        { encode: Date.now() - encodeStartTime },
+                        source_image.get_metrics());
+                const tile = {
                     image: image,
                     headers: options.headers,
                     stats: stats_tile
                 };
-                next();
-            });
+                tiles[key] = tile;
+                if (tile_num === tiles_length) {
+                    return callback(null, tiles);
+                }
+            }
         });
-    }, function(err) {
-        if (err) return callback(err);
-        callback(null, tiles);
     });
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -198,7 +198,7 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
     // acquire can throw if pool is draining
     try {
         this._pool.acquire((err, map) => {
-            if (err) return callback(err);
+            if (err) return callback(err, keys);
 
             // Begin at metatile boundary.
             options.x = meta.x;
@@ -213,7 +213,7 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
                 map.render(image, options, (err, image) => {
                     this._pool.release(map);
                     if (err) {
-                        return callback(err);
+                        return callback(err, keys);
                     }
                     if (meta.tiles.length > 1) {
                         renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);

--- a/lib/render.js
+++ b/lib/render.js
@@ -3,48 +3,6 @@ const mime = require('mime');
 
 const MapnikSource = require('./mapnik_backend');
 
-const EARTH_RADIUS = 6378137;
-const EARTH_DIAMETER = EARTH_RADIUS * 2;
-const EARTH_CIRCUMFERENCE = EARTH_DIAMETER * Math.PI;
-const MAX_RES = EARTH_CIRCUMFERENCE / 256;
-const ORIGIN_SHIFT = EARTH_CIRCUMFERENCE/2;
-
-
-exports['calculateMetatile'] = calculateMetatile;
-function calculateMetatile(options) {
-    var z = +options.z, x = +options.x, y = +options.y;
-    var total = Math.pow(2, z);
-    var resolution = MAX_RES / total;
-
-    // Make sure we start at a metatile boundary.
-    x -= x % options.metatile;
-    y -= y % options.metatile;
-
-    // Make sure we don't calculcate a metatile that is larger than the bounds.
-    var metaWidth  = Math.min(options.metatile, total, total - x);
-    var metaHeight = Math.min(options.metatile, total, total - y);
-
-    // Generate all tile coordinates that are within the metatile.
-    var tiles = [];
-    for (var dx = 0; dx < metaWidth; dx++) {
-        for (var dy = 0; dy < metaHeight; dy++) {
-            tiles.push([ z, x + dx, y + dy ]);
-        }
-    }
-
-    var minx = (x * 256) * resolution - ORIGIN_SHIFT;
-    var miny = -((y + metaHeight) * 256) * resolution + ORIGIN_SHIFT;
-    var maxx = ((x + metaWidth) * 256) * resolution - ORIGIN_SHIFT;
-    var maxy = -((y * 256) * resolution - ORIGIN_SHIFT);
-    return {
-        width: metaWidth * options.tileSize,
-        height: metaHeight * options.tileSize,
-        x: x, y: y,
-        tiles: tiles,
-        bbox: [ minx, miny, maxx, maxy ]
-    };
-}
-
 exports['sliceMetatile'] = sliceMetatile;
 function sliceMetatile(source, source_image, options, meta, stats, callback) {
     const tiles_length = meta.tiles.length;
@@ -155,20 +113,16 @@ function getImage(source, image, options, x, y, callback) {
 }
 
 // Render png/jpg/tif image or a utf grid and return an encoded buffer
-// Uses callback(err, keys, tiles). Returns keys
-MapnikSource.prototype._renderMetatile = function(options, callback) {
-    var source = this;
-
-    // Calculate bbox from xyz, respecting metatile settings.
-    var meta = calculateMetatile(options);
+MapnikSource.prototype._renderMetatile = function(options, meta, callback) {
+    let image = null;
 
     // Set default options.
     if (options.format === 'utf') {
-        options.layer = source._info.interactivity_layer;
-        options.fields = source._info.interactivity_fields;
-        options.resolution = source._uri.query.resolution;
+        options.layer = this._info.interactivity_layer;
+        options.fields = this._info.interactivity_fields;
+        options.resolution = this._uri.query.resolution;
         options.headers = { 'Content-Type': 'application/json' };
-        var image = new mapnik.Grid(meta.width, meta.height);
+        image = new mapnik.Grid(meta.width, meta.height);
     } else {
         // NOTE: formats use mapnik syntax like `png8:m=h` or `jpeg80`
         // so we need custom handling for png/jpeg
@@ -181,62 +135,49 @@ MapnikSource.prototype._renderMetatile = function(options, callback) {
             // will default to 'application/octet-stream' if unable to detect
             options.headers = { 'Content-Type': mime.getType(options.format.split(':')[0]) };
         }
-        var image = new mapnik.Image(meta.width, meta.height);
+        image = new mapnik.Image(meta.width, meta.height);
     }
-    image.metrics_enabled = options.metrics || false;
-
-    options.variables = options.variables || {};
-    options.scale = +source._uri.query.scale;
-
+    options.scale = +this._uri.query.scale;
     // Add reference to the source allowing debug/stat reporting to be compiled.
-    options.source = source;
+    options.source = this;
 
-    const keys = meta.tiles.map(function(tile) {
-        return options.format + ',' + tile.join(',');
-    });
+    // Enable metrics if requested
+    image.metrics_enabled = options.metrics || false;
 
     // acquire can throw if pool is draining
     try {
         this._pool.acquire((err, map) => {
-            if (err) return callback(err, keys);
+            if (err) return callback(err);
 
-            // Begin at metatile boundary.
-            options.x = meta.x;
-            options.y = meta.y;
-            options.variables.zoom = options.z;
             map.resize(meta.width, meta.height);
             map.extent = meta.bbox;
             try {
-                source._stats.render++;
+                this._stats.render++;
                 const renderStats = {};
                 const renderStartTime = Date.now();
                 map.render(image, options, (err, image) => {
                     this._pool.release(map);
                     if (err) {
-                        return callback(err, keys);
+                        return callback(err);
                     }
                     if (meta.tiles.length > 1) {
                         renderStats.render = Math.round((Date.now() - renderStartTime) / meta.tiles.length);
-                        sliceMetatile(source, image, options, meta, renderStats, (err, tiles) => {
-                            return callback(err, keys, tiles);
+                        sliceMetatile(this, image, options, meta, renderStats, (err, tiles) => {
+                            return callback(err, tiles);
                         });
                     } else {
                         renderStats.render = Date.now() - renderStartTime;
-                        encodeSingleTile(source, image, options, meta, renderStats, (err, tiles) => {
-                            return callback(err, keys, tiles);
+                        encodeSingleTile(this, image, options, meta, renderStats, (err, tiles) => {
+                            return callback(err, tiles);
                         });
                     }
                 });
             } catch(err) {
                 this._pool.release(map);
-                return callback(err, keys);
+                return callback(err);
             }
         });
     } catch (err) {
-        return callback(err, keys);
+        return callback(err);
     }
-
-    // Return a list of all the tile coordinates that are being rendered
-    // as part of this metatile.
-    return keys;
 };

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "dependencies": {
         "@carto/mapnik": "3.6.2-carto.11",
         "generic-pool": "3.4.2",
-        "mime": "2.3.1",
-        "step": "~0.0.5"
+        "mime": "2.3.1"
     },
     "devDependencies": {
         "mocha": "5.2.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ],
     "dependencies": {
         "@carto/mapnik": "3.6.2-carto.11",
-        "generic-pool": "~2.4.0",
+        "generic-pool": "3.4.2",
         "mime": "2.3.1",
         "step": "~0.0.5"
     },

--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
         "Blake Thompson <flippmoke>"
     ],
     "dependencies": {
-        "step": "~0.0.5",
-        "generic-pool": "~2.4.0",
         "@carto/mapnik": "3.6.2-carto.11",
-        "mime": "~1.6.0",
-        "sphericalmercator": "~1.0.4"
+        "generic-pool": "~2.4.0",
+        "mime": "1.6.0",
+        "step": "~0.0.5"
     },
     "devDependencies": {
         "mocha": "5.2.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "@carto/mapnik": "3.6.2-carto.11",
         "generic-pool": "~2.4.0",
-        "mime": "1.6.0",
+        "mime": "2.3.1",
         "step": "~0.0.5"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ],
     "dependencies": {
         "@carto/mapnik": "3.6.2-carto.11",
-        "generic-pool": "3.4.2",
+        "generic-pool": "2.5.4",
         "mime": "2.3.1"
     },
     "devDependencies": {

--- a/test/metatile.test.js
+++ b/test/metatile.test.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var render = require('../lib/render');
+var backend = require('../lib/mapnik_backend');
 
 var FULL = 20037508.342789244;
 var HALF = 0;
@@ -14,39 +14,39 @@ describe('metatile', function() {
             bbox: [ -FULL, -FULL, FULL, FULL ],
             x: 0, y: 0
         };
-        assert.deepEqual(render.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 1, tileSize: 256 }), tile);
-        assert.deepEqual(render.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 2, tileSize: 256 }), tile);
-        assert.deepEqual(render.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 3, tileSize: 256 }), tile);
-        assert.deepEqual(render.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 4, tileSize: 256 }), tile);
-        assert.deepEqual(render.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 13, tileSize: 256 }), tile);
+        assert.deepEqual(backend.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 1, tileSize: 256 }), tile);
+        assert.deepEqual(backend.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 2, tileSize: 256 }), tile);
+        assert.deepEqual(backend.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 3, tileSize: 256 }), tile);
+        assert.deepEqual(backend.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 4, tileSize: 256 }), tile);
+        assert.deepEqual(backend.calculateMetatile({ z: 0, x: 0, y: 0, metatile: 13, tileSize: 256 }), tile);
         done();
     });
     
     it('test metatile calculation at z=1', function(done) {
         // metatile: 1
         {
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 1, tileSize: 256}), {
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 1, tileSize: 256}), {
                 width: 256,
                 height: 256,
                 tiles: [ [1, 0, 0] ],
                 bbox: [ -FULL, HALF, HALF, FULL ],
                 x: 0, y: 0
             });
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [1, 0, 1] ],
                 bbox: [ -FULL, -FULL, HALF, HALF ],
                 x: 0, y: 1
             });
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [1, 1, 0] ],
                 bbox: [ HALF, HALF, FULL, FULL ],
                 x: 1, y: 0
             });
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [1, 1, 1] ],
@@ -64,34 +64,34 @@ describe('metatile', function() {
         };
         // metatile: 2
         {
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 2, tileSize: 256 }), tile);
         }
     
         // metatile: 3
         {
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 3, tileSize: 256 }), tile);
         }
     
         // metatile: 4
         {
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 4, tileSize: 256 }), tile);
         }
     
         // metatile: 13
         {
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 0, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 0, y: 1, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 0, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 1, x: 1, y: 1, metatile: 13, tileSize: 256 }), tile);
         }
         done();
     });
@@ -99,28 +99,28 @@ describe('metatile', function() {
     it('test metatile calculation at z=2', function(done) {
         // metatile: 1
         {
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 0, 0] ],
                 bbox: [ -FULL, QUAD, -QUAD, FULL ],
                 x: 0, y: 0
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 0, 1] ],
                 bbox: [ -FULL, HALF, -QUAD, QUAD ],
                 x: 0, y: 1
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 0, 2] ],
                 bbox: [ -FULL, -QUADX, -QUAD, HALF ],
                 x: 0, y: 2
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 0, 3] ],
@@ -128,28 +128,28 @@ describe('metatile', function() {
                 x: 0, y: 3
             });
     
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 1, 0] ],
                 bbox: [ -QUAD, QUAD, HALF, FULL ],
                 x: 1, y: 0
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 1, 1] ],
                 bbox: [ -QUAD, HALF, HALF, QUAD ],
                 x: 1, y: 1
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 1, 2] ],
                 bbox: [ -QUAD, -QUADX, HALF, HALF ],
                 x: 1, y: 2
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 1, 3] ],
@@ -157,28 +157,28 @@ describe('metatile', function() {
                 x: 1, y: 3
             });
     
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 2, 0] ],
                 bbox: [ HALF, QUAD, QUADX, FULL ],
                 x: 2, y: 0
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 2, 1] ],
                 bbox: [ HALF, HALF, QUADX, QUAD ],
                 x: 2, y: 1
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 2, 2] ],
                 bbox: [ HALF, -QUADX, QUADX, HALF ],
                 x: 2, y: 2
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 2, 3] ],
@@ -186,28 +186,28 @@ describe('metatile', function() {
                 x: 2, y: 3
             });
     
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 3, 0] ],
                 bbox: [ QUADX, QUAD, FULL, FULL ],
                 x: 3, y: 0
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 3, 1] ],
                 bbox: [ QUADX, HALF, FULL, QUAD ],
                 x: 3, y: 1
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 3, 2] ],
                 bbox: [ QUADX, -QUADX, FULL, HALF ],
                 x: 3, y: 2
             });
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 1, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 1, tileSize: 256 }), {
                 width: 256,
                 height: 256,
                 tiles: [ [2, 3, 3] ],
@@ -224,10 +224,10 @@ describe('metatile', function() {
                 bbox: [ -FULL, HALF, -HALF, FULL ],
                 x: 0, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 2, tileSize: 256 }), tile);
     
             var tile = {
                 width: 512, height: 512,
@@ -235,10 +235,10 @@ describe('metatile', function() {
                 bbox: [ HALF, HALF, FULL, FULL ],
                 x: 2, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 2, tileSize: 256 }), tile);
     
             var tile = {
                 width: 512, height: 512,
@@ -246,10 +246,10 @@ describe('metatile', function() {
                 bbox: [ -FULL, -FULL, -HALF, HALF ],
                 x: 0, y: 2
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 2, tileSize: 256 }), tile);
     
     
             var tile = {
@@ -258,10 +258,10 @@ describe('metatile', function() {
                 bbox: [ HALF, -FULL, FULL, HALF ],
                 x: 2, y: 2
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 2, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 2, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 2, tileSize: 256 }), tile);
         }
     
         // metatile: 3
@@ -272,15 +272,15 @@ describe('metatile', function() {
                 bbox: [ -FULL, -QUADX, QUADX, FULL ],
                 x: 0, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 3, tileSize: 256 }), tile);
     
             var tile = {
                 width: 768, height: 256,
@@ -288,9 +288,9 @@ describe('metatile', function() {
                 bbox: [ -FULL, -FULL, QUADX, -QUADX ],
                 x: 0, y: 3
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 3, tileSize: 256 }), tile);
     
             var tile = {
                 width: 256, height: 768,
@@ -298,11 +298,11 @@ describe('metatile', function() {
                 bbox: [ QUADX, -QUADX, FULL, FULL ],
                 x: 3, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 3, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 3, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 3, tileSize: 256 }), tile);
     
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 3, tileSize: 256 }), {
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 3, tileSize: 256 }), {
                 width: 256, height: 256,
                 tiles: [ [2, 3, 3] ],
                 bbox: [ QUADX, -FULL, FULL, -QUADX ],
@@ -318,22 +318,22 @@ describe('metatile', function() {
                 bbox: [ -FULL, -FULL, FULL, FULL ],
                 x: 0, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 4, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 4, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 4, tileSize: 256 }), tile);
         }
     
         // metatile: 5
@@ -344,22 +344,22 @@ describe('metatile', function() {
                 bbox: [ -FULL, -FULL, FULL, FULL ],
                 x: 0, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 5, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 5, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 5, tileSize: 256 }), tile);
         }
     
         // metatile: 13
@@ -370,22 +370,22 @@ describe('metatile', function() {
                 bbox: [ -FULL, -FULL, FULL, FULL ],
                 x: 0, y: 0
             };
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 13, tileSize: 256 }), tile);
-            assert.deepEqual(render.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 0, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 1, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 2, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 0, y: 3, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 0, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 1, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 2, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 1, y: 3, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 0, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 1, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 2, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 2, y: 3, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 0, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 1, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 2, metatile: 13, tileSize: 256 }), tile);
+            assert.deepEqual(backend.calculateMetatile({ z: 2, x: 3, y: 3, metatile: 13, tileSize: 256 }), tile);
         }
             done();
     });

--- a/test/uri.test.js
+++ b/test/uri.test.js
@@ -111,12 +111,17 @@ describe('uri query options', function() {
     describe('metrics', function() {
 
         function makeUri(metrics) {
-            var query = {};
+            const uri = {
+                protocol : "mapnik:",
+                pathname : "./test/data/test.xml",
+                query : { }
+            };
+
             if (metrics !== undefined) {
-                query.metrics = metrics;
+                uri.query.metrics = metrics;
             }
 
-            return { query };
+            return uri;
         }
 
         it('Defaults to false', function() {


### PR DESCRIPTION
- Removes unused dependency `sphericalmercator`.
- Removes usage of `step` and calls to `process.nextTick` that I think are no longer necessary.
- Updates generic-pool to 3.4.2.
- Some minor cleaning up with ES6 features.
- The changes in the tests are due to an error that was being hidden by step.

As I worked in the pool and step at the same time the commits cannot be picked individually.